### PR TITLE
Fix floating text on repo name and desc

### DIFF
--- a/src/components/repoCard.js
+++ b/src/components/repoCard.js
@@ -33,8 +33,17 @@ const RepoCard = ({ repo }) => {
           height: '80%',
         }}
       >
-        <Text sx={{ fontSize: 20, py: '8px' }}>{repo.name}</Text>
-        <Text sx={{ fontSize: 16, py: '4px', color: '#9d1e1e' }}>
+        <Text sx={{ wordBreak: 'break-all', fontSize: 20, py: '8px' }}>
+          {repo.name}
+        </Text>
+        <Text
+          sx={{
+            wordBreak: 'break-all',
+            fontSize: 16,
+            py: '4px',
+            color: '#9d1e1e',
+          }}
+        >
           {repo.full_name}
         </Text>
         <Text


### PR DESCRIPTION
Fix Issue Floating Text #41

Before 
![Screen Shot 2020-11-11 at 10 55 10](https://user-images.githubusercontent.com/10354610/98763543-ccda5400-240c-11eb-98ca-fe18106dc49e.png)

After
![Screen Shot 2020-11-11 at 10 56 40](https://user-images.githubusercontent.com/10354610/98763567-d794e900-240c-11eb-9f43-cef45a64d6ad.png)
